### PR TITLE
!!!TASK: Remove temporaryDirectoryPath setting

### DIFF
--- a/TYPO3.Flow/Classes/TYPO3/Flow/Core/Bootstrap.php
+++ b/TYPO3.Flow/Classes/TYPO3/Flow/Core/Bootstrap.php
@@ -284,7 +284,9 @@ class Bootstrap
         }
 
         $sequence->addStep(new Step('typo3.flow:annotationregistry', array(\TYPO3\Flow\Core\Booting\Scripts::class, 'registerClassLoaderInAnnotationRegistry')));
-        $sequence->addStep(new Step('typo3.flow:configuration', array(\TYPO3\Flow\Core\Booting\Scripts::class, 'initializeConfiguration')), 'typo3.flow:annotationregistry');
+        $sequence->addStep(new Step('typo3.flow:environment', array(\TYPO3\Flow\Core\Booting\Scripts::class, 'initializeEnvironment')), 'typo3.flow:annotationregistry');
+        $sequence->addStep(new Step('typo3.flow:configuration', array(\TYPO3\Flow\Core\Booting\Scripts::class, 'initializeConfiguration')), 'typo3.flow:environment');
+        $sequence->addStep(new Step('typo3.flow:lockmanager', array(\TYPO3\Flow\Core\Booting\Scripts::class, 'initializeLockManager')), 'typo3.flow:configuration');
         $sequence->addStep(new Step('typo3.flow:systemlogger', array(\TYPO3\Flow\Core\Booting\Scripts::class, 'initializeSystemLogger')), 'typo3.flow:configuration');
 
         $sequence->addStep(new Step('typo3.flow:errorhandling', array(\TYPO3\Flow\Core\Booting\Scripts::class, 'initializeErrorHandling')), 'typo3.flow:systemlogger');


### PR DESCRIPTION
This removed the ``temporaryDirectoryPath``setting that was deprecated since
Flow 3.1. This also allows to unclutter the boot steps taken.